### PR TITLE
[FEATURE] Add SYCL feature flags to rllm-llamacpp build (To add support for Intel GPUs)

### DIFF
--- a/rllm/llama-cpp-low/Cargo.toml
+++ b/rllm/llama-cpp-low/Cargo.toml
@@ -16,3 +16,6 @@ cmake = "0.1.50"
 [features]
 default = []
 cuda = []
+sycl = []
+sycl_fp16 = []
+sycl_nvidia = []

--- a/rllm/rllm-cuda/server.sh
+++ b/rllm/rllm-cuda/server.sh
@@ -41,6 +41,38 @@ while [ "$1" != "" ] ; do
               exit 1
             fi
             ;;
+        --sycl )
+            if [ "$CPP" = 1 ] ; then
+              VER="$VER --features sycl"
+            else
+              echo "--sycl only valid for llama.cpp"
+              exit 1
+            fi
+            ;;
+        --sycl-fp16 )
+            if [ "$CPP" = 1 ] ; then
+              VER="$VER --features \"sycl,sycl-fp16\""
+            else
+              echo "--sycl-fp16 only valid for llama.cpp"
+              exit 1
+            fi
+            ;;
+        --sycl-nvidia )
+            if [ "$CPP" = 1 ] ; then
+              VER="$VER --features \"sycl,sycl-nvidia\""
+            else
+              echo "--sycl-nvidia only valid for llama.cpp"
+              exit 1
+            fi
+            ;;
+        --sycl-nvidia-fp16 )
+            if [ "$CPP" = 1 ] ; then
+              VER="$VER --features \"sycl,sycl-nvidia,sycl-fp16\""
+            else
+              echo "--sycl-nvidia-fp16 only valid for llama.cpp"
+              exit 1
+            fi
+            ;;
         --trace )
             R_LOG=info,tokenizers=error,rllm=trace,aicirt=info,llama_cpp_low=trace
             ;;
@@ -84,7 +116,7 @@ if [ "$CPP" = 1 ] ; then
     * )
     SELF="server.sh"
     cat <<EOF
-usage: $SELF [--loop] [--cuda] [--debug] [model_name] [rllm_args...]
+usage: $SELF [--loop] [--cuda] [--sycl] [--sycl-fp16] [--sycl-nvidia] [--debug] [model_name] [rllm_args...]
 
 model_name can a HuggingFace URL pointing to a .gguf file, or one of the following:
 
@@ -96,9 +128,14 @@ model_name can a HuggingFace URL pointing to a .gguf file, or one of the followi
 
 Additionally, "$SELF build" will just build the server, and not run a model.
 
-  --cuda   try to build llama.cpp against installed CUDA
-  --loop   restart server when it crashes and store logs in ./logs
-  --debug  don't build in --release mode
+  --cuda              try to build llama.cpp against installed CUDA
+  --sycl              try to build llama.cpp against SYCL with fp32 support
+  --sycl-fp16         try to build llama.cpp against SYCL with fp16 support
+  --sycl-nvidia       try to build llama.cpp against SYCL with nvidia support
+  --sycl-nvidia-fp16  try to build llama.cpp against SYCL with fp16 and nvidia support
+  --sycl              try to build llama.cpp against installed SYCL (Plz make sure to )
+  --loop              restart server when it crashes and store logs in ./logs
+  --debug             don't build in --release mode
 
 Try $SELF phi2 --help to see available rllm_args
 EOF

--- a/rllm/rllm-llamacpp/Cargo.toml
+++ b/rllm/rllm-llamacpp/Cargo.toml
@@ -21,3 +21,6 @@ path = "src/rllm-llamacpp.rs"
 [features]
 default = []
 cuda = ["llama_cpp_low/cuda"]
+sycl = ["llama_cpp_low/sycl"]
+sycl_fp16 = ["llama_cpp_low/sycl_fp16"]
+sycl_nvidia = ["llama_cpp_low/sycl_nvidia"]


### PR DESCRIPTION
The goal of this pull request is to add support for Intel GPU to the build script of rllm llama.cpp
This is done by
 - expanding the cargo feature flags of rllm-llamacpp and rllm-llamacpp_low and incoporate
 - adding the needed build arguments in the main.rs from rllm-llamacpp_low
 - and adding appropriate new options to server.sh
 
 The code will be tested on a machine with Intel 13Gen Processor & Intel Arc A770 GPU